### PR TITLE
Makes all tests pass in OSX

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ var url = require('url')
   , fs = require('fs')
   , path = require('path')
   , glob = require('glob')
-  , watch = require('fs-watch-tree').watchTree
+  , watchr = require('watchr')
   , copy = require('./copy')
   , File = require('./file')
   , http = require('http')
@@ -28,25 +28,35 @@ module.exports = function buffet(root, opts) {
   readyQueue.setMaxListeners(0);
 
   if (options.watch) {
-    watch(root, {exclude: [/^\./]}, buffetWatcher);
+    watchr.watch({
+      path: root,
+      listener: buffetWatcher,
+      ignoreHiddenFiles: true,
+      ignorePatterns: true
+    });
 
-    function buffetWatcher(event) {
-      if (event.isDirectory()) return;
-      var urlPath = event.name.substring(root.length);
-      var filePath = event.name;
-      if (event.isModify()) {
-        try {
-          cache[urlPath] = new File(filePath, options);
-          // Index support
-          if (isIndex(urlPath)) {
-            cache[path.dirname(urlPath)] = cache[urlPath];
+    function buffetWatcher(event, filePath, stat, prevStat) {
+      var urlPath = filePath.substring(root.length);
+      if (event === 'new' || event === 'change') {
+        if (stat.isDirectory()) {
+          if (event === 'new') {
+            serveBuffet.rebuild(filePath);
           }
         }
-        catch (e) {
-          delete cache[urlPath];
+        else {
+          try {
+            cache[urlPath] = new File(filePath, options);
+            // Index support
+            if (isIndex(urlPath)) {
+              cache[path.dirname(urlPath)] = cache[urlPath];
+            }
+          }
+          catch (e) {
+            delete cache[urlPath];
+          }
         }
       }
-      else if (event.isDelete()) {
+      else if (event === 'unlink') {
         delete cache[urlPath];
         if (isIndex(urlPath)) {
           delete cache[path.dirname(urlPath)];
@@ -55,8 +65,9 @@ module.exports = function buffet(root, opts) {
     }
   }
 
-  function primeBuffet() {
-    glob(root + '/**', {mark: true}, function(err, matches) {
+  function primeBuffet(rootPath) {
+    rootPath = rootPath || root;
+    glob(rootPath + '/**', {mark: true}, function(err, matches) {
       if (err) {
         console.error(err);
         ready = true;
@@ -146,12 +157,28 @@ module.exports = function buffet(root, opts) {
       }
     }
   };
-  serveBuffet.rebuild = function(cb) {
+  serveBuffet.rebuild = function(rootPath, cb) {
+    if (typeof rootPath === 'function') {
+      cb = rootPath;
+      rootPath = null;
+    }
     onReady(function() {
       ready = false;
-      cache = {};
-      primeBuffet();
-      onReady(cb);
+      if (rootPath) {
+        var rootUrlPath = rootPath.substring(root.length);
+        Object.keys(cache).forEach(function(urlPath) {
+          if (urlPath.indexOf(rootUrlPath) === 0) {
+            delete cache[urlPath];
+          }
+        });
+      }
+      else {
+        cache = {};
+      }
+      primeBuffet(rootPath);
+      onReady(function() {
+        if (cb) cb();
+      });
     });
   };
   return serveBuffet;

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "mime": "~1.2.6",
     "node_hash": "~0.2.0",
     "gzip-buffer": "0.0.2",
-    "fs-watch-tree": "~0.2.2",
     "glob": "~3.1.10",
     "optimist": "~0.3.4",
-    "accesslog": "~0.0.1"
+    "accesslog": "~0.0.1",
+    "watchr": "~2.1.2"
   },
   "keywords": [
     "static",

--- a/test/simple.js
+++ b/test/simple.js
@@ -128,9 +128,7 @@ describe('simple test', function() {
         fs.writeFile(testFolder + '/folder/' + folderName + '/test.json', JSON.stringify(testData), function(err) {
           assert.ifError(err);
           // Give time for the watcher to pick it up
-          setTimeout(function() {
-            done();
-          }, 1000);
+          setTimeout(done, 1000);
         });
       });
     });
@@ -151,6 +149,31 @@ describe('simple test', function() {
         });
       }).on('error', assert.ifError);
       req.end();
+    });
+
+    it('serves an updated file', function(done) {
+      testData.boo = false;
+      fs.writeFile(testFolder + '/folder/' + folderName + '/test.json', JSON.stringify(testData), function(err) {
+        assert.ifError(err);
+        // Give the watcher some time.
+        setTimeout(function() {
+          var req = http.get(baseUrl + '/folder/' + folderName + '/test.json', function(res) {
+            assert.equal(res.statusCode, 200);
+            assert.equal(res.headers['content-type'], 'application/json');
+
+            var data = '';
+            res.setEncoding('utf8');
+            res.on('data', function(chunk) {
+              data += chunk;
+            });
+            res.on('end', function() {
+              assert.deepEqual(JSON.parse(data), testData);
+              done();
+            });
+          }).on('error', assert.ifError);
+          req.end();
+        }, 1000);
+      });
     });
 
     it('serves a 404 after removing dynamic file', function(done) {

--- a/test/simple.js
+++ b/test/simple.js
@@ -128,7 +128,7 @@ describe('simple test', function() {
         fs.writeFile(testFolder + '/folder/' + folderName + '/test.json', JSON.stringify(testData), function(err) {
           assert.ifError(err);
           // Give time for the watcher to pick it up
-          setTimeout(done, 1000);
+          setTimeout(done, 100);
         });
       });
     });
@@ -172,7 +172,7 @@ describe('simple test', function() {
             });
           }).on('error', assert.ifError);
           req.end();
-        }, 1000);
+        }, 100);
       });
     });
 
@@ -195,7 +195,7 @@ describe('simple test', function() {
           });
         }).on('error', assert.ifError);
         req.end();
-        }, 1000);
+        }, 100);
       });
     });
 


### PR DESCRIPTION
Switches to the [watchr](https://github.com/bevry/watchr) module.  Note: watchr is written in coffee :(  It is possible we might be able to stick with your current watcher but my fix requires being able to identify the difference between new folders and updated ones.

Adds optional rootPath param to primeBuffet() and rebuild().  This is then used in the watch handler to rebuild new directories that the watcher finds (at least in OSX, only the folder triggers a notification, not the files inside it).

The tests should be run in Linux before merging is considered.
