### PR TITLE
Fixes safari caching problem.

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -96,6 +96,10 @@ File.prototype.serve = function(req, res, status) {
     if (req.method === 'HEAD') {
       body = null;
     }
+    if (!body) {
+      delete(headers['Content-Encoding']);
+      delete(headers['Content-Length']);
+    }
 
     if (this.keepAlive && ((res.response && res.response.shouldKeepAlive) || res.shouldKeepAlive)) {
       headers['Keep-Alive'] = 'timeout=' + this.keepAlive;


### PR DESCRIPTION
Don't send Content-Encoding or Content-Length when sending null body.
