### PR TITLE
Worker should report actual listening port

### DIFF
--- a/bin/buffet.js
+++ b/bin/buffet.js
@@ -65,7 +65,7 @@ for (var i = 0; i < options.threads; i++) {
     if (message.cmd === 'BUFFET_UP') {
       workerCount++;
       if (workerCount === options.threads) {
-        console.error('buffet ' + version + ' listening on port ' + options.port);
+        console.error('buffet ' + version + ' listening on port ' + message.port);
       }
     }
   });

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -21,6 +21,6 @@ function start (options) {
 
   // Send status back to cluster master
   server.listen(options.port, function () {
-    process.send({cmd: 'BUFFET_UP'});
+    process.send({cmd: 'BUFFET_UP', port: this.address().port});
   });
 }


### PR DESCRIPTION
If you pass `-p 0` to the command-line script, the server will select a random available port, as expected. But of course printing "listening on port 0" to the console is not helpful.

So, the worker will report the listening port, and the command-line script will use that value to print the listening port to the console.
