### PR TITLE
Better maxAge handling, allows zero as value

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Options
 - `watch`: True to auto-update the buffer when files change. (Default: `true`)
 - `poweredBy`: True to add the `X-Powered-By` header. (Default: `true`)
 - `maxAge`: Number of max-age seconds to set `Cache-Control` header. Set to
-  `false` or `0` to disable. (Default: `300`)
+  `false` to disable. (Default: `300`)
 - `notFoundPath`: Path to be rendered on `buffetMiddleware.notFound`. (Default:
   `/404.html`)
 - <del>keepAlive</del>: **This option is removed as of `v0.6.1`**. The intention was to

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,9 @@ module.exports = function buffet(root, opts) {
     }
   });
   options.defaultContentType = options.defaultContentType || 'application/octet-stream';
-  options.maxAge || (options.maxAge = 300);
+  if (typeof options.maxAge !== 'number' && options.maxAge !== null) {
+    options.maxAge = 300;
+  }
   options.index || (options.index = 'index.html');
   options.notFoundPath || (options.notFoundPath = '/404.html');
   if (options.notFoundPath[0] !== '/') {


### PR DESCRIPTION
This pull request needs https://github.com/carlos8f/node-dish/pull/2

Problem is the same -- unable to achive header "Cache-Control: max-age=0".
Checking for null here is because of commander's option predefined type. It will work not only with 'false' option, but anything's that not a Number.
